### PR TITLE
Update README for Config Options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -74,10 +74,10 @@ if you want to deactivate root authentication before user binding :
      <<: *ldap_defaults
 
 to use ldaps add:
-     simple_tls: true
+     ldaps: true
 
 to use start tls add:
-     start_tls: true
+     starttls: true
 
 if you need to set openssl options add a "tls_options" hash e.g.:
      tls_options:


### PR DESCRIPTION
Just fixing the docs to properly specify the keys for ldaps/start tls :)  These don't work as written, and instead the code is looking for these values. 

As per: https://github.com/Ultragreen/rack-auth-ldap/blob/master/lib/rack/auth/ldap.rb#L133-L136

Thanks for creating this. 